### PR TITLE
add postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-ollama",
-  "version": "1.0.8",
+  "version": "1.2.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -35,7 +35,9 @@
     "lint": "prettier --write ./src",
     "clean": "rm -rf dist .turbo node_modules .turbo-tsconfig.json tsconfig.tsbuildinfo",
     "format": "prettier --write ./src",
-    "format:check": "prettier --check ./src"
+    "format:check": "prettier --check ./src",
+    "test": "bun test",
+    "postinstall": "bun scripts/install-ollama.js"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/install-ollama.js
+++ b/scripts/install-ollama.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from 'bun';
+import { platform } from 'os';
+
+const isWindows = platform() === 'win32';
+const isMac = platform() === 'darwin';
+const isLinux = platform() === 'linux';
+
+console.log('Installing Ollama...');
+
+try {
+  // Check if Ollama is already installed
+  const checkResult = spawnSync(['ollama', '--version'], {
+    stdout: 'pipe',
+    stderr: 'pipe'
+  });
+  
+  if (checkResult.exitCode === 0) {
+    console.log('Ollama is already installed.');
+  } else {
+    // Ollama not installed, proceed with installation
+    if (isWindows) {
+      console.log('Please download and install Ollama from: https://ollama.com/download/windows');
+      console.log('After installation, run: ollama pull nomic-embed-text');
+      process.exit(0);
+    } else if (isMac || isLinux) {
+      console.log('Installing Ollama using the official installer...');
+      const installResult = spawnSync(['sh', '-c', 'curl -fsSL https://ollama.com/install.sh | sh'], {
+        stdout: 'inherit',
+        stderr: 'inherit'
+      });
+      
+      if (installResult.exitCode !== 0) {
+        throw new Error('Failed to install Ollama');
+      }
+    } else {
+      console.error('Unsupported platform. Please install Ollama manually from: https://ollama.com/download');
+      process.exit(1);
+    }
+  }
+
+  // Pull the required embedding model
+  console.log('\nPulling required embedding model...');
+  console.log('Pulling nomic-embed-text...');
+  const pullNomic = spawnSync(['ollama', 'pull', 'nomic-embed-text'], {
+    stdout: 'inherit',
+    stderr: 'inherit'
+  });
+  
+  if (pullNomic.exitCode !== 0) {
+    throw new Error('Failed to pull nomic-embed-text model');
+  }
+  
+  console.log('\nOllama installation and model setup complete!');
+} catch (error) {
+  console.error('Error during installation:', error.message);
+  console.error('\nPlease install Ollama manually from: https://ollama.com/download');
+  process.exit(1);
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "bun:test";
+import { ollamaPlugin } from "./index";
+
+describe("ollamaPlugin", () => {
+  it("should export ollamaPlugin", () => {
+    expect(ollamaPlugin).toBeDefined();
+  });
+
+  it("should have the correct name", () => {
+    expect(ollamaPlugin.name).toBe("ollama");
+  });
+
+  it("should have an init method", () => {
+    expect(ollamaPlugin.init).toBeDefined();
+    expect(typeof ollamaPlugin.init).toBe("function");
+  });
+
+  it("should have providers array", () => {
+    expect(ollamaPlugin.providers).toBeDefined();
+    expect(Array.isArray(ollamaPlugin.providers)).toBe(true);
+  });
+});
+EOF < /dev/null

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-  },
-});


### PR DESCRIPTION
## Summary
- Removed unused vitest configuration file
- Migrated to bun:test for testing framework
- Updated install script to use bun's native spawnSync instead of Node's execSync
- Modified model pulling behavior to only pull embedding model

## Changes
1. **Removed vitest.config.ts** - The project had no actual test files using vitest, and vitest wasn't listed in dependencies
2. **Added bun test script** - Added `"test": "bun test"` to package.json scripts
3. **Created example test file** - Added `src/index.test.ts` with basic tests using bun:test syntax
4. **Updated install script** - Replaced Node.js `execSync` with bun's `spawnSync` for better compatibility
5. **Modified model installation** - Changed to only pull `nomic-embed-text` model (removed `gemma3` pull)

## Test plan
- [ ] Run `bun test` to verify test setup works
- [ ] Run `bun install` to verify postinstall script works correctly
- [ ] Verify ollama installation process on different platforms
- [ ] Confirm build still works with `bun run build`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated installation script for Ollama that runs after dependencies are installed.
  * Introduced a test suite for the Ollama plugin to verify its structure and exports.

* **Chores**
  * Updated the package version to 1.2.0.
  * Added scripts for running tests and post-installation tasks.
  * Removed the Vitest configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->