### PR TITLE
Fix ollama install script for CI environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-ollama",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/scripts/install-ollama.js
+++ b/scripts/install-ollama.js
@@ -3,6 +3,12 @@
 import { $ } from 'bun';
 import { platform } from 'os';
 
+// Skip postinstall in CI/test environments
+if (process.env.CI || process.env.GITHUB_ACTIONS || process.env.TEST_MODE) {
+  console.log('Skipping Ollama installation in CI/test environment');
+  process.exit(0);
+}
+
 const isWindows = platform() === 'win32';
 const isMac = platform() === 'darwin';
 const isLinux = platform() === 'linux';

--- a/scripts/install-ollama.js
+++ b/scripts/install-ollama.js
@@ -1,60 +1,54 @@
 #!/usr/bin/env bun
 
-import { spawnSync } from 'bun';
+import { $ } from 'bun';
 import { platform } from 'os';
 
 const isWindows = platform() === 'win32';
 const isMac = platform() === 'darwin';
 const isLinux = platform() === 'linux';
 
-console.log('Installing Ollama...');
+console.log('Checking Ollama installation...');
 
-try {
-  // Check if Ollama is already installed
-  const checkResult = spawnSync(['ollama', '--version'], {
-    stdout: 'pipe',
-    stderr: 'pipe'
-  });
-  
-  if (checkResult.exitCode === 0) {
-    console.log('Ollama is already installed.');
-  } else {
-    // Ollama not installed, proceed with installation
-    if (isWindows) {
-      console.log('Please download and install Ollama from: https://ollama.com/download/windows');
-      console.log('After installation, run: ollama pull nomic-embed-text');
-      process.exit(0);
-    } else if (isMac || isLinux) {
-      console.log('Installing Ollama using the official installer...');
-      const installResult = spawnSync(['sh', '-c', 'curl -fsSL https://ollama.com/install.sh | sh'], {
-        stdout: 'inherit',
-        stderr: 'inherit'
-      });
-      
-      if (installResult.exitCode !== 0) {
-        throw new Error('Failed to install Ollama');
+async function main() {
+  try {
+    // Check if ollama is already installed
+    try {
+      await $`ollama --version`.quiet();
+      console.log('Ollama is already installed.');
+    } catch {
+      // Ollama not installed, try to install it
+      if (isWindows) {
+        console.log('Windows detected. Please download and install Ollama from: https://ollama.com/download/windows');
+        console.log('After installation, run: ollama pull nomic-embed-text');
+        return;
+      } else if (isMac || isLinux) {
+        console.log('Installing Ollama using the official installer...');
+        try {
+          await $`curl -fsSL https://ollama.com/install.sh | sh`;
+          console.log('Ollama installed successfully!');
+        } catch (error) {
+          console.warn('Could not install Ollama automatically. This might be a CI environment.');
+          console.log('Please install Ollama manually from: https://ollama.com/download');
+          return;
+        }
+      } else {
+        console.log('Unsupported platform. Please install Ollama manually from: https://ollama.com/download');
+        return;
       }
-    } else {
-      console.error('Unsupported platform. Please install Ollama manually from: https://ollama.com/download');
-      process.exit(1);
     }
-  }
 
-  // Pull the required embedding model
-  console.log('\nPulling required embedding model...');
-  console.log('Pulling nomic-embed-text...');
-  const pullNomic = spawnSync(['ollama', 'pull', 'nomic-embed-text'], {
-    stdout: 'inherit',
-    stderr: 'inherit'
-  });
-  
-  if (pullNomic.exitCode !== 0) {
-    throw new Error('Failed to pull nomic-embed-text model');
+    // Try to pull the required model
+    console.log('\nTrying to pull required embedding model...');
+    try {
+      await $`ollama pull nomic-embed-text`;
+      console.log('Successfully pulled nomic-embed-text model!');
+    } catch (error) {
+      console.log('Could not pull model. You may need to run "ollama pull nomic-embed-text" manually after starting Ollama.');
+    }
+    
+  } catch (error) {
+    console.error('Unexpected error:', error.message);
   }
-  
-  console.log('\nOllama installation and model setup complete!');
-} catch (error) {
-  console.error('Error during installation:', error.message);
-  console.error('\nPlease install Ollama manually from: https://ollama.com/download');
-  process.exit(1);
 }
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Updated the ollama install script to handle CI environments gracefully
- Prevents installation failures from breaking the build process
- Converts hard errors to warnings for non-critical failures

## Changes
- Rewrote script using Bun's `$` template literals for cleaner async/await syntax
- Removed `process.exit(1)` calls that cause CI failures
- Added graceful handling when ollama cannot be installed (common in CI)
- Continues execution even if model pull fails

## Test plan
- [x] Script runs without errors in local development
- [x] Script handles missing ollama gracefully
- [ ] CI build passes with these changes

This fixes the CI failure seen in GitHub Actions where the postinstall script was exiting with code 1.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the installation process for Ollama with asynchronous checks and clearer status messages.
  * Enhanced user guidance for manual installation on unsupported platforms or when automatic installation fails.
* **Chores**
  * Updated package version to 1.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->