### PR TITLE
Fix static embedding size return on null input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,16 +214,18 @@ export const ollamaPlugin: Plugin = {
               ? (params as TextEmbeddingParams).text || ""
               : "";
 
+        // If no text is provided (e.g., for dimension detection), use a default text
+        const embeddingText = text || "test";
+        
         if (!text) {
-          logger.error("No text provided for embedding");
-          return Array(1536).fill(0);
+          logger.debug("No text provided for embedding, using default text for dimension detection");
         }
 
         // Use ollama.embedding() as shown in the docs
         try {
           const { embedding } = await embed({
             model: ollama.embedding(modelName),
-            value: text,
+            value: embeddingText,
           });
           return embedding;
         } catch (embeddingError) {


### PR DESCRIPTION
Problem,The `ensureEmbeddingDimension` method is calling this.useModel(ModelType.TEXT_EMBEDDING, null) with null as the input, but the Ollama embedding model expects actual text input. When it recieve null it defaults to a embedding size, which in runtime wont work with agnostic embedding models. The fix just adds temp text, so it returns to proper embedding size.